### PR TITLE
Fixed crash caused by outdated meta key

### DIFF
--- a/scripts/events/events.py
+++ b/scripts/events/events.py
@@ -146,7 +146,7 @@ class EventListener:
 			self.shiftPressed = True
 		elif keyval in (fife.Key.LEFT_ALT, fife.Key.RIGHT_ALT):
 			self.altPressed = True
-		elif keyval in (fife.Key.RIGHT_META, fife.Key.LEFT_META):
+		elif keyval in (fife.Key.LEFT_SUPER, fife.Key.RIGHT_SUPER):
 			self.metaPressed = True
 	
 		elif keyval == fife.Key.ESCAPE:
@@ -179,7 +179,7 @@ class EventListener:
 			self.shiftPressed = False
 		elif keyval in (fife.Key.LEFT_ALT, fife.Key.RIGHT_ALT):
 			self.altPressed = False
-		elif keyval in (fife.Key.RIGHT_META, fife.Key.LEFT_META):
+		elif keyval in (fife.Key.LEFT_SUPER, fife.Key.RIGHT_SUPER):
 			self.metaPressed = False
 
 	


### PR DESCRIPTION
Whenever you pressed a key, the application froze. This was caused by a problem similar to #23 where a name was updated in fifengine but not in the editor code. Now keys should work (except the `d` key which crashes the application, I don't know a fix for this, as it does not give me a stacktrace).

For reference, the keys are located at `fifengine/engine/core/eventchannel/key/ec_key.h`.
